### PR TITLE
pass parent-matrix via resolving children instead of context

### DIFF
--- a/packages/solid-webgpu/src/canvas.tsx
+++ b/packages/solid-webgpu/src/canvas.tsx
@@ -1,9 +1,10 @@
 import createRAF from '@solid-primitives/raf'
 import { Vec3 } from 'math'
-import { batch, createEffect, mergeProps, onCleanup, ParentProps, splitProps } from 'solid-js'
+import { batch, children, createEffect, For, mergeProps, onCleanup, ParentProps, splitProps } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { CameraRef } from './camera'
 import { SceneContext, SceneContextProvider } from './context'
+import { isObject3DInterface } from './object3d'
 import {
   CameraContext,
   GeometryContext,
@@ -231,7 +232,12 @@ export const Canvas = (props: CanvasProps) => {
   return (
     <SceneContextProvider value={[scene, setScene]}>
       {canvas}
-      {cProps.children}
+      <For each={children(() => cProps.children).toArray()}>{child => {
+        if(isObject3DInterface(child)){
+          return child?.render()
+        }
+        return child
+      }}</For>
     </SceneContextProvider>
   )
 }

--- a/packages/solid-webgpu/src/object3d.tsx
+++ b/packages/solid-webgpu/src/object3d.tsx
@@ -164,9 +164,9 @@ export const createObject3DContext = <T,>(
 }
 
 export const Object3D = (props: Object3DProps) => {
-  const { store, Provider: Provider } = createObject3DContext(['Object3D'], props, {})
+  const { store, Provider } = createObject3DContext(['Object3D'], props, {})
 
   props.ref?.(store)
-
+  
   return <Provider>{props.children}</Provider>
 }

--- a/packages/solid-webgpu/src/object3d.tsx
+++ b/packages/solid-webgpu/src/object3d.tsx
@@ -1,8 +1,20 @@
 import { Mat4, Quat, QuatLike, Vec3, Vec3Like } from 'math'
-import { createEffect, createSignal, createUniqueId, ParentProps, splitProps } from 'solid-js'
+import {
+  Accessor,
+  children,
+  createEffect,
+  createSignal,
+  createUniqueId,
+  For,
+  JSXElement,
+  ParentProps,
+  splitProps
+} from 'solid-js'
 import { createStore } from 'solid-js/store'
-import { NodeContextProvider, Object3DContextProvider, useObject3DContext, useSceneContext } from './context'
+import { NodeContextProvider, Object3DContextProvider, useSceneContext } from './context'
 import { NodeContext, NodeProps, NodeRef, Object3DContext, Object3DExtra } from './types'
+
+const $OBJECT3D = Symbol()
 
 export type Object3DRef<T = {}> = NodeRef<T>
 export type Object3DProps<T = {}> = NodeProps<T> &
@@ -11,6 +23,15 @@ export type Object3DProps<T = {}> = NodeProps<T> &
     quaternion?: QuatLike
     scale?: Vec3Like
   }
+
+interface Object3DInterface {
+  render(): JSXElement
+  setParentMatrix(matrix: Accessor<Accessor<Mat4>>): void
+}
+
+export const isObject3DInterface = (value: unknown): value is Object3DInterface => {
+  return !!(value && typeof value === 'object' && $OBJECT3D in value)
+}
 
 export const createNodeContext = <T,>(
   type: string[],
@@ -75,6 +96,7 @@ export const createObject3DContext = <T,>(
   const id = _s.id
   const [scene] = useSceneContext()
   const [store, setStore] = createStore(scene.nodes[id] as Object3DContext)
+  const [parentMatrix, setParentMatrix] = createSignal<Accessor<Mat4>>()
 
   createEffect(() => {
     store.setPosition(v => {
@@ -97,16 +119,16 @@ export const createObject3DContext = <T,>(
     })
   })
 
-  // update matrix
-  const parentCtx = useObject3DContext()
   createEffect(() => {
     const { quaternion, position, scale } = store
     store.setMatrix(m => {
       Mat4.fromRotationTranslationScale(m, quaternion(), position(), scale())
-      if (parentCtx && parentCtx[0]) {
-        const pm = parentCtx[0].matrix()
-        Mat4.mul(m, pm, m)
+
+      const pm = parentMatrix()
+      if(pm){
+        Mat4.mul(m, pm(), m)
       }
+
       return m
     })
   })
@@ -115,18 +137,35 @@ export const createObject3DContext = <T,>(
     store,
     setStore,
     Provider: (p: ParentProps) => {
-      return (
-        <Provider>
-          <Object3DContextProvider value={[store, setStore]}>{p.children}</Object3DContextProvider>
-        </Provider>
-      )
-    }
+      return {
+        [$OBJECT3D]: true,
+        setParentMatrix,
+        render() {
+          return (
+            <Provider>
+              <Object3DContextProvider value={[store, setStore]}>
+                <For each={children(() => p.children).toArray()}>
+                  {child => {
+                    if (isObject3DInterface(child)) {
+                      child.setParentMatrix(() => store.matrix)
+                      return child.render()
+                    }
+                    return child
+                  }}
+                </For>
+              </Object3DContextProvider>
+            </Provider>
+          )
+        }
+      } as unknown as JSXElement
+    } 
   }
 }
 
 export const Object3D = (props: Object3DProps) => {
-  const { store, Provider } = createObject3DContext(['Object3D'], props, {})
+  const { store, Provider: Provider } = createObject3DContext(['Object3D'], props, {})
 
   props.ref?.(store)
+
   return <Provider>{props.children}</Provider>
 }

--- a/packages/solid-webgpu/src/object3d.tsx
+++ b/packages/solid-webgpu/src/object3d.tsx
@@ -96,7 +96,6 @@ export const createObject3DContext = <T,>(
   const id = _s.id
   const [scene] = useSceneContext()
   const [store, setStore] = createStore(scene.nodes[id] as Object3DContext)
-  const [parentMatrix, setParentMatrix] = createSignal<Accessor<Mat4>>()
 
   createEffect(() => {
     store.setPosition(v => {
@@ -119,6 +118,8 @@ export const createObject3DContext = <T,>(
     })
   })
 
+  // update matrix
+  const [parentMatrix, setParentMatrix] = createSignal<Accessor<Mat4>>()
   createEffect(() => {
     const { quaternion, position, scale } = store
     store.setMatrix(m => {


### PR DESCRIPTION
**before**
- context was used to connect parent to child
- because context is only initialised during mount this can lead to unexpected results.

p.ex
```tsx
function Component(){
  const shape = <Shape/> 
  return <Parent>{shape}</Parent> 
}
```
will not actually connect Shape to Parent. Similarly it would not be able to switch from parent without needing to re-mount the component.

**after**
- pass parent-matrix via resolving children instead of context:
    - `createObject3DContext.Provider` returns `Object3DInterface { [$OBJECT3D]: true, setParentMatrix, render }`
    - render-function 
        - checks if child is `Object3DInterface` (checks for that `$OBJECT3D`-symbol) 
        - if so: passes accessor to its matrix to the child and calls its render-function and return the result.
        - if not: just returns the node.
   - similarly in canvas we do the same check and call render, but without passing a matrix.
   
 ```tsx
const App = () => {
  const [camera, setCamera] = createSignal<CameraRef>()
  const [canvas, setCanvas] = createSignal<HTMLCanvasElement>()

  return (
    <Canvas camera={camera()} ref={setCanvas}>
      <PerspectiveCamera label="main_camera" ref={setCamera} position={[0, 0, 5]} aspect={16 / 9} />
      {(() => {
        const model = (
          <Mesh>
            <UnlitMaterial />
            <Plane />
          </Mesh>
        )
        return <Object3D position={[1, 2, 0]}>{model}</Object3D>
      })()}
    </Canvas>
  )
}
```
this now renders as expected. 

<img width="957" alt="Screenshot 2024-12-04 at 18 32 26" src="https://github.com/user-attachments/assets/7dac3c18-5da1-499f-8f6b-ee84807f4b3a">

The model in the above snippet still needs to be initialised inside `<Canvas/>` because there is other state that depends on context. In principle these could also be implemented with a similar approach.